### PR TITLE
Fix for CoffeeScript 1.7.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,8 @@
-require('coffee-script');
+var CoffeeScript = require('coffee-script');
+
+if(CoffeeScript.register)
+{
+    CoffeeScript.register();
+}
 
 module.exports = require('./lib/index');


### PR DESCRIPTION
CoffeeScript 1.7 made the following change:

_When requiring CoffeeScript files in Node you must now explicitly register the compiler. This can be done with `require 'coffee-script/register'` or `CoffeeScript.register()`. Also for configuration such as Mocha's, use `coffee-script/register`._

Without this change, requiring mecab-ffi throws:

```
Error: Cannot find module './lib/index'
```
