### PR TITLE
Fix unknown variable errors in extractKeywords()

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -145,7 +145,7 @@ MeCab.extractKeywords = (inputString, options, callback) ->
       if morpheme[1] is 'SN'
         tempSN = morpheme[0]
 
-      else if ( prevMorpheme[1] is 'NNG' or prevMorpheme[1] is 'NNP' or prevMorpheme[1] is 'NNB' or prevMorpheme[1] is 'NR' or prevMorpheme[1] is 'NP' ) and morpheme[0].length > 1 and morpheme[4] is '*'
+      else if ( morpheme[1] is 'NNG' or morpheme[1] is 'NNP' or morpheme[1] is 'NNB' or morpheme[1] is 'NR' or morpheme[1] is 'NP' ) and morpheme[0].length > 1 and morpheme[2] is '*'
         nouns.push "#{tempSN}#{morpheme[0]}"
         tempSN = ''
 


### PR DESCRIPTION
extractKeywords() was failing on 'should'. I modified variable names accordingly and fixed morpheme index from 4 to 2 to match new array pattern.

-handrake

---

> mecab-ffi@0.1.0 test /home/handrake/project/node-mecab-ffi
> mocha --compilers coffee:coffee-script --require coffee-script/register --globals lw --recursive ./test -t 10000

  mecab
    .parse(...)

```
  ✓ should be done
.parseSync(...)

  ✓ should be done
muptiple parse(...)

  ✓ should be done
.extractKeywords(...)

  1) should be done
getDiceCoefficientByString(...)

  ✓ should be done
```

  4 passing (66ms)
  1 failing

  1) mecab .extractKeywords(...) should be done:
     Uncaught ReferenceError: prevMorpheme is not defined
    at lib/index.coffee:148:17
    at lib/index.coffee:86:5
    at lib/index.coffee:81:9

npm ERR! Test failed.  See above for more details.
npm WARN This failure might be due to the use of legacy binary "node"
npm WARN For further explanations, please read
/usr/share/doc/nodejs/README.Debian

npm ERR! not ok code 0

---

morpheme array pattern

[ '몸', 'NNG', '*', 'T', '몸', '*', '*', '*', '*' ]
[ '의', 'JKG', '*', 'F', '의', '*', '*', '*', '*' ]
[ '체질', 'NNG', '*', 'T', '체질', '*', '*', '*', '*' ]
