### PR TITLE
fixed some noun codes

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -108,10 +108,10 @@ MeCab.extractNouns = (inputString, callback) ->
 
     nouns = []
     for morpheme, index in morphemes
-      if morpheme[1] is 'NNG' or morpheme[1] is 'NNP' or morpheme[1] is 'NNB' or morpheme[1] is 'NR' or morpheme[1] is 'NP'
+      if morpheme[1] is 'NNG' or morpheme[1] is 'NNP' or morpheme[1] is 'NP'
         if index > 0
           prevMorpheme = morphemes[index - 1]
-          if prevMorpheme[1] is 'SN' or ( prevMorpheme[1] is 'NNG' or prevMorpheme[1] is 'NNP' or prevMorpheme[1] is 'NNB' or prevMorpheme[1] is 'NR' or prevMorpheme[1] is 'NP' ) or prevMorpheme[1] is 'VA+ETM'
+          if prevMorpheme[1] is 'SN' or ( prevMorpheme[1] is 'NNG' or prevMorpheme[1] is 'NNP' or prevMorpheme[1] is 'NP' ) or prevMorpheme[1] is 'VA+ETM'
             nouns.push "#{prevMorpheme[0]} #{morpheme[0]}"
 
           if index > 1
@@ -119,7 +119,7 @@ MeCab.extractNouns = (inputString, callback) ->
             if prevPrevMorpheme[1] is 'VA' and prevMorpheme[1] is 'ETM'
               nouns.push "#{prevPrevMorpheme[0]}#{prevMorpheme[0]} #{morpheme[0]}"
         
-        nouns.push morpheme[0]  if morpheme[1] is 'NNG' or morpheme[1] is 'NNP' or morpheme[1] is 'NNB' or morpheme[1] is 'NR' or morpheme[1] is 'NP'
+        nouns.push morpheme[0]  if morpheme[1] is 'NNG' or morpheme[1] is 'NNP' or morpheme[1] is 'NP'
 
     callback null, nouns
 
@@ -145,7 +145,7 @@ MeCab.extractKeywords = (inputString, options, callback) ->
       if morpheme[1] is 'SN'
         tempSN = morpheme[0]
 
-      else if ( prevMorpheme[1] is 'NNG' or prevMorpheme[1] is 'NNP' or prevMorpheme[1] is 'NNB' or prevMorpheme[1] is 'NR' or prevMorpheme[1] is 'NP' ) and morpheme[0].length > 1 and morpheme[4] is '*'
+      else if ( prevMorpheme[1] is 'NNG' or prevMorpheme[1] is 'NNP' or prevMorpheme[1] is 'NP' ) and morpheme[0].length > 1 and morpheme[4] is '*'
         nouns.push "#{tempSN}#{morpheme[0]}"
         tempSN = ''
 


### PR DESCRIPTION
#11 related, some noun codes are not suitable.

Refer to [the tag dictionary](https://docs.google.com/spreadsheets/d/1-9blXKjtjeKZqsf4NzHeYJCrr49-nXeRF6D80udfcwY/edit#gid=0), [prior PR(19671bf)](https://github.com/9bow/node-mecab-ffi/commit/19671bff4da62bd11d96ec5b3ce1f3019f6392e8) should not include 'NNB/의존명사(bound-noun)', 'NR/수사(numeral)' and 'NP/대명사(pronoun)'.

So removed two noun codes('NNB' and 'NR'), but didn't 'NP' cause it's suitable I think. (if not, please remove this.)